### PR TITLE
Ruby 3.4 compatibility

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,9 +10,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    date (3.3.4)
+    date (3.4.1)
     diff-lcs (1.5.1)
-    json (2.7.2)
+    json (2.9.1)
     language_server-protocol (3.17.0.3)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
@@ -20,7 +20,7 @@ GEM
       net-pop
       net-smtp
     mini_mime (1.1.5)
-    net-imap (0.4.14)
+    net-imap (0.5.5)
       date
       net-protocol
     net-pop (0.1.2)
@@ -30,51 +30,51 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     parallel (1.26.3)
-    parser (3.3.4.2)
+    parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
     racc (1.8.1)
-    rack (3.1.7)
+    rack (3.1.8)
     rainbow (3.1.1)
     rake (13.2.1)
-    regexp_parser (2.9.2)
-    rexml (3.3.9)
+    regexp_parser (2.10.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.0)
+    rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.2)
+    rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.1)
+    rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.1)
-    rubocop (1.65.1)
+    rspec-support (3.13.2)
+    rubocop (1.69.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 2.4, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.31.1, < 2.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.36.2, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.32.1)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.37.0)
       parser (>= 3.3.1.0)
-    rubocop-performance (1.21.1)
+    rubocop-performance (1.23.1)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
-    rubocop-rspec (3.0.4)
+    rubocop-rspec (3.3.0)
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
-    timeout (0.4.1)
-    unicode-display_width (2.5.0)
+    timeout (0.4.3)
+    unicode-display_width (3.1.3)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
 
 PLATFORMS
   ruby
@@ -90,4 +90,4 @@ DEPENDENCIES
   rubocop-rspec
 
 BUNDLED WITH
-   2.5.3
+   2.6.2


### PR DESCRIPTION
Add Ruby 3.4 to the test matrix and check compatibility.